### PR TITLE
Adding availability to trip and segment

### DIFF
--- a/tripgo.swagger.yaml
+++ b/tripgo.swagger.yaml
@@ -2788,6 +2788,13 @@ definitions:
         description:
           Mode identifier. Will match input, e.g., `routing.json`'s `modes`. See
           http://skedgo.github.io/tripgo-api/site/advanced/#mode-identifiers.
+      availability:
+        type: string
+        description: Indicates availability of the segment, e.g., if it's too late to book this segment for the requested departure time, or if a scheduled service has been cancelled.
+        enum:
+          - AVAILABLE
+          - MISSED_PREBOOKING_WINDOW
+          - CANCELLED
       action:
         type: string
         description: Localised single-line instruction for this segment. Can include placeholders.
@@ -2818,6 +2825,7 @@ definitions:
 
     required:
       - hashCode
+      - availability
       - action
       - visibility
       - type
@@ -2939,6 +2947,13 @@ definitions:
         description:
           Hash code for the primary segment of this trip, which can
           be used for giving the trip a name, e.g., "Bus trip".
+      availability:
+        type: string
+        description: Indicates availability of the trip, e.g., if it's too late to book a trip for the requested departure time, or if a scheduled service has been cancelled.
+        enum:
+          - AVAILABLE
+          - MISSED_PREBOOKING_WINDOW
+          - CANCELLED
       caloriesCost:
         type: number
         description: Total active calories used up for the full trip
@@ -2993,6 +3008,7 @@ definitions:
       - arrive
       - segments
       - mainSegmentHashCode
+      - availability
       - weightedScore
       - hassleCost
       - carbonCost


### PR DESCRIPTION
New indicator for availability (issues) of a trip or its segments.

Should only be merged once those new properties are reflected in all production servers (https://github.com/skedgo/skedgo-java/pull/505).