### PR TITLE
Source attribution for trip groups

### DIFF
--- a/tripgo.swagger.yaml
+++ b/tripgo.swagger.yaml
@@ -2580,7 +2580,7 @@ definitions:
         disclaimer:
           type: string
           description: |
-            Official disclaimer for this segment, which should be displayed with the trip.
+            **Deprecated.** Official disclaimer for this segment, which should be displayed with the trip.
         stopCode:
           type: string
           description: Start stop code
@@ -2746,8 +2746,13 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Trip'
+      sources:
+        type: array
+        items:
+          $ref: '#/definitions/DataSourceAttribution'
     required:
       - trips
+      - sources
 
   TTPSolution:
     properties:


### PR DESCRIPTION
1. Added `TripGroup.sources`
2. Deprecated `SegmentTemplateMovingTransit.disclaimer`