### PR TITLE
specificModes field in regionInfo.json

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2019,8 +2019,24 @@ definitions:
       - title
 
   ModeDetails:
-    description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+    description: This is a map/dictionary with multiple items of this type. Each key is a generic mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+    allOf:
+    - $ref: '#/definitions/SpecificModeDetails'
+    - type: object
+      properties:
+        specificModes:
+          type: array
+          items:
+            $ref: '#/definitions/SpecificModeDetails'
+    required:
+      - title
+
+  SpecificModeDetails:
     properties:
+      identifier:
+        description: |
+          Typically a mode-identifier, e.g., `pt_pub_bus` or `pt_pub`.
+        type: string
       title:
         type: string
       URL:
@@ -2039,12 +2055,6 @@ definitions:
       remoteDarkIcon:
         description: Part of icon file name for dark background that can be  fetched from server.
         type: string
-      type:
-        type: string
-        enum:
-          - public_transport
-          - taxi_and_tnc
-          - shared_vehicles
       integrations:
         type: array
         items:
@@ -2055,7 +2065,7 @@ definitions:
             - bookings
             - payments
     required:
-      - type
+      - identifier
 
   OpeningHours:
     properties:
@@ -2394,10 +2404,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ModeInfo'
-      specificModes:
+      modes:
         type: object
         properties:
-          $modeIdentifier:
+          $genericModeIdentifier:
             $ref: '#/definitions/ModeDetails'
       transitWheelchairAccessibility:
         type: boolean
@@ -2460,6 +2470,153 @@ definitions:
             - identifier: pt_pub_train
               alt: train
               localIcon: train
+      modes:
+        cy_bic-s:
+          color:
+            blue: 99
+            green: 199
+            red: 30
+          identifier: cy_bic-s
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 56
+              green: 22
+              red: 236
+            identifier: cy_bic-s_norisbike-nurnberg
+            integrations:
+            - real_time
+            - routing
+            title: NorisBike
+            url: http://www.norisbike.de
+          title: Bike share
+        me_car-p:
+          color:
+            blue: 199
+            green: 196
+            red: 46
+          identifier: me_car-p
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 184
+              green: 132
+              red: 19
+            identifier: me_car-p_BlaBlaCar
+            integrations:
+            - routing
+            remoteIcon: blablacar
+            title: BlaBlaCar
+            url: https://www.blablacar.com
+          title: Carpooling
+        me_car-r:
+          color:
+            blue: 243
+            green: 169
+            red: 115
+          identifier: me_car-r
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 243
+              green: 169
+              red: 115
+            identifier: me_car-r_SwiftFleet
+            integrations:
+            - routing
+            title: Car rental
+          title: Car rental
+        me_car-s:
+          color:
+            blue: 243
+            green: 169
+            red: 115
+          identifier: me_car-s
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 27
+              green: 13
+              red: 252
+            identifier: me_car-s_FLINK
+            integrations:
+            - real_time
+            - routing
+            title: Flinkster
+            url: https://www.flinkster.de
+          title: Car share
+        ps_tax:
+          color:
+            blue: 62
+            green: 202
+            red: 221
+          identifier: ps_tax
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 0
+              green: 0
+              red: 0
+            identifier: ps_tax_MYDRIVER
+            integrations:
+            - routing
+            remoteIcon: mydriver
+            title: myDriver
+            url: https://mydriver.com
+          title: Taxi
+        ps_tnc:
+          color:
+            blue: 243
+            green: 169
+            red: 115
+          identifier: ps_tnc
+          integrations:
+          - routing
+          specificModes:
+          - color:
+              blue: 47
+              green: 255
+              red: 47
+            identifier: ps_tnc_ODB
+            integrations:
+            - real_time
+            - routing
+            remoteIcon: skedgo
+            title: Skedgo
+            url: https://www.skedgo.com
+          title: Ride share
+        pt_pub:
+          color:
+            blue: 104
+            green: 197
+            red: 45
+          identifier: pt_pub
+          integrations:
+          - routing
+          specificModes:
+          - alt: train
+            identifier: pt_pub_train
+            localIcon: train
+          - alt: subway
+            color:
+              blue: 165
+              green: 103
+              red: 0
+            identifier: pt_pub_subway
+            localIcon: subway
+            remoteIcon: subway-germany
+          - alt: tram
+            identifier: pt_pub_tram
+            localIcon: tram
+          - alt: bus
+            identifier: pt_pub_bus
+            localIcon: bus
+          title: Public transport
 
   Service:
     description: Details of public transport service

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -19,10 +19,10 @@ info:
   contact:
     name: SkedGo API Team
     email: api@skedgo.com
-    url: https://developer.tripgo.com/
+    url: "https://developer.tripgo.com/"
   license:
     name: Apache License 2.0
-    url: https://github.com/skedgo/tripgo-api/blob/gh-pages/LICENSE
+    url: "https://github.com/skedgo/tripgo-api/blob/gh-pages/LICENSE"
 host: api.tripgo.com
 basePath: /v1
 schemes:
@@ -996,7 +996,7 @@ paths:
         This variant using cell IDs is recommended if the client wants to cache locations locally, while frequently calling this endpoint to make sure the local data is update without requiring a lot of data overhead (and having most of the logic on the server). For an explanation, [please see our developer site](https://developer.tripgo.com/faq#locations-cell-ids-and-hash-codes).
       externalDocs:
         description: Locations, cell IDs and hash codes
-        url: https://developer.tripgo.com/faq/#locations-cell-ids-and-hash-codes
+        url: "https://developer.tripgo.com/faq/#locations-cell-ids-and-hash-codes"
       parameters:
         - name: input
           in: body
@@ -1397,23 +1397,8 @@ definitions:
         type: object
         properties:
           $modeIdentifier:
-            type: object
             description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
-            properties:
-              title:
-                type: string
-              URL:
-                type: string
-              color:
-                $ref: '#/definitions/Color'
-              icon:
-                type: string
-                description: File name part for downloading an image for this mode. [See separate documentation](TODO) for how to construct a URL from this.
-              implies:
-                type: string
-                description: Another mode identifier that is required by this one, e.g., you can't request only school buses without also requesting regular public transport.
-            required:
-              - title
+            $ref: '#/definitions/ModeIdentifier'
 
   RegionInfoInput:
     type: object
@@ -2015,56 +2000,62 @@ definitions:
       - alt
       - localIcon
 
-  SpecificModes:
-    description: Specific modes grouped by type
+  ModeIdentifier:
+    description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
     properties:
-      public_transport:
-        $ref: '#/definitions/PublicTransportModeDetails'
-      taxi_and_tnc:
-        $ref: '#/definitions/TaxiAndTNCModeDetails'
-      shared_vehicles:
-        $ref: '#/definitions/SharedVehiclesModeDetails'
-
-  PublicTransportModeDetails:
-    description: list of public transit services that are accessible to public.
-    allOf:
-    - $ref: '#/definitions/ModeDetails'
-    required:
-      - alt
-      - localIcon
-
-  TaxiAndTNCModeDetails:
-    description: list of taxi-like on-demand services, including regular taxis, Uber, Lyft, etc.
-    allOf:
-    - $ref: '#/definitions/ModeDetails'
-    required:
-      - title
-
-  SharedVehiclesModeDetails:
-    description: list of shared vehicles services, including bikes (like Bicing) and cars (like ZipCar or GoGet)
-    allOf:
-    - $ref: '#/definitions/ModeDetails'
+      title:
+        type: string
+      URL:
+        type: string
+      color:
+        $ref: '#/definitions/Color'
+      icon:
+        type: string
+        description: File name part for downloading an image for this mode. [See separate documentation](TODO) for how to construct a URL from this.
+      implies:
+        type: string
+        description: Another mode identifier that is required by this one, e.g., you can't request only school buses without also requesting regular public transport.
     required:
       - title
 
   ModeDetails:
-    allOf:
-    - $ref: '#/definitions/ModeInfo'
-    - type: object
-      properties:
-        title:
+    description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+    properties:
+      title:
+        type: string
+      URL:
+        type: string
+      color:
+        $ref: '#/definitions/Color'
+      alt:
+        description: Textual alternative to icon
+        type: string
+      localIcon:
+        description: Part of icon file name that should be shipped with app.
+        type: string
+      remoteIcon:
+        description: Part of icon file name that can be fetched from server.
+        type: string
+      remoteDarkIcon:
+        description: Part of icon file name for dark background that can be  fetched from server.
+        type: string
+      type:
+        type: string
+        enum:
+          - public_transport
+          - taxi_and_tnc
+          - shared_vehicles
+      integrations:
+        type: array
+        items:
           type: string
-        URL:
-          type: string
-        integrations:
-          type: array
-          items:
-            type: string
-            enum:
-              - routing
-              - real_time
-              - bookings
-              - payments
+          enum:
+            - routing
+            - real_time
+            - bookings
+            - payments
+    required:
+      - type
 
   OpeningHours:
     properties:
@@ -2404,7 +2395,10 @@ definitions:
         items:
           $ref: '#/definitions/ModeInfo'
       specificModes:
-          $ref: '#/definitions/SpecificModes'
+        type: object
+        properties:
+          $modeIdentifier:
+            $ref: '#/definitions/ModeDetails'
       transitWheelchairAccessibility:
         type: boolean
         description: Whether the TripGo API includes wheelchair accessibility information for public transport for this region.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2021,17 +2021,23 @@ definitions:
   ModeDetails:
     description: This is a map/dictionary with multiple items of this type. Each key is a generic mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
     allOf:
-    - $ref: '#/definitions/SpecificModeDetails'
+    - $ref: '#/definitions/SharedModeDetails'
     - type: object
       properties:
         specificModes:
+          description: Specific Modes enabled
+          type: array
+          items:
+            $ref: '#/definitions/SpecificModeDetails'
+        lockedModes:
+          description: Specific Modes requiring specific credentials
           type: array
           items:
             $ref: '#/definitions/SpecificModeDetails'
     required:
       - title
 
-  SpecificModeDetails:
+  SharedModeDetails:
     properties:
       identifier:
         description: |
@@ -2055,16 +2061,29 @@ definitions:
       remoteDarkIcon:
         description: Part of icon file name for dark background that can be  fetched from server.
         type: string
-      integrations:
-        type: array
-        items:
-          type: string
-          enum:
-            - routing
-            - real_time
-            - bookings
-            - payments
+
+  SpecificModeDetails:
+    allOf:
+    - $ref: '#/definitions/SharedModeDetails'
+    - type: object
+      properties:
+        operators:
+          description: List of public operators names, see `operators` field
+          type: array
+          items:
+            type: string
+        integrations:
+          description: Integrations enabled
+          type: array
+          items:
+            type: string
+            enum:
+              - routing
+              - real_time
+              - bookings
+              - payments
     required:
+      - title
       - identifier
 
   OpeningHours:
@@ -2427,8 +2446,15 @@ definitions:
               enum:
                 - IS_REAL_TIME
                 - INCAPABLE
+            modes:
+              type: array
+              description: List of available modes, see `modes` field
+              items:
+                type: string
             types:
               type: array
+              description: |
+                **Deprecated.** replaced with `modes`
               items:
                 $ref: '#/definitions/ModeInfo'
           required:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2015,6 +2015,57 @@ definitions:
       - alt
       - localIcon
 
+  SpecificModes:
+    description: Specific modes grouped by type
+    properties:
+      public_transport:
+        $ref: '#/definitions/PublicTransportModeDetails'
+      taxi_and_tnc:
+        $ref: '#/definitions/TaxiAndTNCModeDetails'
+      shared_vehicles:
+        $ref: '#/definitions/SharedVehiclesModeDetails'
+
+  PublicTransportModeDetails:
+    description: list of public transit services that are accessible to public.
+    allOf:
+    - $ref: '#/definitions/ModeDetails'
+    required:
+      - alt
+      - localIcon
+
+  TaxiAndTNCModeDetails:
+    description: list of taxi-like on-demand services, including regular taxis, Uber, Lyft, etc.
+    allOf:
+    - $ref: '#/definitions/ModeDetails'
+    required:
+      - title
+
+  SharedVehiclesModeDetails:
+    description: list of shared vehicles services, including bikes (like Bicing) and cars (like ZipCar or GoGet)
+    allOf:
+    - $ref: '#/definitions/ModeDetails'
+    required:
+      - title
+
+  ModeDetails:
+    allOf:
+    - $ref: '#/definitions/ModeInfo'
+    - type: object
+      properties:
+        title:
+          type: string
+        URL:
+          type: string
+        integrations:
+          type: array
+          items:
+            type: string
+            enum:
+              - routing
+              - real_time
+              - bookings
+              - payments
+
   OpeningHours:
     properties:
       timezone:
@@ -2352,6 +2403,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ModeInfo'
+      specificModes:
+          $ref: '#/definitions/SpecificModes'
       transitWheelchairAccessibility:
         type: boolean
         description: Whether the TripGo API includes wheelchair accessibility information for public transport for this region.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2489,13 +2489,24 @@ definitions:
             blue: 211
             green: 157
       operators:
-        - name: HVV
-          numberOfServices: 65123
-          realTimeStatus: INCAPABLE
-          types:
-            - identifier: pt_pub_train
-              alt: train
-              localIcon: train
+      - name: VGN
+        modes:
+        - pt_pub_subway
+        - pt_pub_bus
+        - pt_pub_tram
+        - pt_pub_train
+        numberOfServices: 50056
+        realTimeStatus: INCAPABLE
+      - name: FlixBus
+        modes:
+        - pt_pub_bus
+        numberOfServices: 1597
+        realTimeStatus: INCAPABLE
+      - name: DPN
+        modes:
+        - pt_pub_train
+        numberOfServices: 201
+        realTimeStatus: INCAPABLE
       modes:
         cy_bic-s:
           color:
@@ -2503,8 +2514,6 @@ definitions:
             green: 199
             red: 30
           identifier: cy_bic-s
-          integrations:
-          - routing
           specificModes:
           - color:
               blue: 56
@@ -2512,8 +2521,8 @@ definitions:
               red: 236
             identifier: cy_bic-s_norisbike-nurnberg
             integrations:
-            - real_time
             - routing
+            - real_time
             title: NorisBike
             url: http://www.norisbike.de
           title: Bike share
@@ -2523,9 +2532,7 @@ definitions:
             green: 196
             red: 46
           identifier: me_car-p
-          integrations:
-          - routing
-          specificModes:
+          lockedModes:
           - color:
               blue: 184
               green: 132
@@ -2543,9 +2550,7 @@ definitions:
             green: 169
             red: 115
           identifier: me_car-r
-          integrations:
-          - routing
-          specificModes:
+          lockedModes:
           - color:
               blue: 243
               green: 169
@@ -2561,17 +2566,15 @@ definitions:
             green: 169
             red: 115
           identifier: me_car-s
-          integrations:
-          - routing
-          specificModes:
+          lockedModes:
           - color:
               blue: 27
               green: 13
               red: 252
             identifier: me_car-s_FLINK
             integrations:
-            - real_time
             - routing
+            - real_time
             title: Flinkster
             url: https://www.flinkster.de
           title: Car share
@@ -2581,9 +2584,7 @@ definitions:
             green: 202
             red: 221
           identifier: ps_tax
-          integrations:
-          - routing
-          specificModes:
+          lockedModes:
           - color:
               blue: 0
               green: 0
@@ -2595,39 +2596,19 @@ definitions:
             title: myDriver
             url: https://mydriver.com
           title: Taxi
-        ps_tnc:
-          color:
-            blue: 243
-            green: 169
-            red: 115
-          identifier: ps_tnc
-          integrations:
-          - routing
-          specificModes:
-          - color:
-              blue: 47
-              green: 255
-              red: 47
-            identifier: ps_tnc_ODB
-            integrations:
-            - real_time
-            - routing
-            remoteIcon: skedgo
-            title: Skedgo
-            url: https://www.skedgo.com
-          title: Ride share
         pt_pub:
           color:
             blue: 104
             green: 197
             red: 45
           identifier: pt_pub
-          integrations:
-          - routing
           specificModes:
           - alt: train
             identifier: pt_pub_train
             localIcon: train
+            operators:
+            - VGN
+            - DPN
           - alt: subway
             color:
               blue: 165
@@ -2635,13 +2616,20 @@ definitions:
               red: 0
             identifier: pt_pub_subway
             localIcon: subway
+            operators:
+            - VGN
             remoteIcon: subway-germany
           - alt: tram
             identifier: pt_pub_tram
             localIcon: tram
+            operators:
+            - VGN
           - alt: bus
             identifier: pt_pub_bus
             localIcon: bus
+            operators:
+            - VGN
+            - FlixBus
           title: Public transport
 
   Service:


### PR DESCRIPTION
This adds a field called `specificModes` with three lists:

- `public_transport`
- `taxi_and_tnc`
- `shared_vehicles`

currently, all three have the same structure, but may differ in the future.

java changes in [PR](https://github.com/skedgo/skedgo-java/pull/940)
