### PR TITLE
add new routing.json flag `2wirc`

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -519,6 +519,11 @@ paths:
           in: query
           description: Boolean if segment templates for public transport should include the list of all stops along the way, including *relative* times (i.e., seconds since start of the segment)
           default: false
+        - name: 2wirc
+          type: boolean
+          in: query
+          description: Boolean to enable/disable two way hires including return costs
+          default: true
       responses:
         200:
           description: Successful response. Can include many trips.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -522,7 +522,7 @@ paths:
         - name: 2wirc
           type: boolean
           in: query
-          description: Boolean to enable/disable two way hires including return costs
+          description: Boolean to determine whether two-way-hire vehicles, such as pod-based car-share, should automatically add the cost of returning the vehicle to its pick-up location. Set to false if the cost of the trip should only include the cost that's attributed to this trip and ignore the unavoidable additional cost for returning the vehicle to its pick-up location.
           default: true
       responses:
         200:


### PR DESCRIPTION
to disable two way hires including return costs (enabled by default)