### PR TITLE
Cycling segments include push-your-bike sections

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3147,6 +3147,12 @@ definitions:
         metresSafe:
           type: integer
           description: Total travel distance that is considered safe for this mode (see description of 'safe' in the 'streets' array)
+        metresUnsafe:
+          type: integer
+          description: Total travel distance that is considered unsafe for this mode (see description of 'safe' in the 'streets' array)
+        metresDismount:
+          type: integer
+          description: Total travel distance that it's considered necessary to push the bicycle (see description of 'dismount' in the 'streets' array)
         streets:
           type: array
           items:
@@ -3160,6 +3166,9 @@ definitions:
               safe:
                 type: boolean
                 description: Indicator for cycle paths if they are cycling-friendly (e.g., there's a bike lane) or for walking paths if they are wheelchair-friendly. Missing if unknown.
+              dismount:
+                type: boolean
+                description: Indicator for dismount sections in cycle paths (e.g., steps).
             required:
               - encodedPolyline
 


### PR DESCRIPTION
With an upcoming update of the TripGo API in mid April 2018, cycling segments will include "push your bike" sections. This change is made to address user and developer feedback of missing cycling and cycling + public transport results, that were due to those paths requiring small sections where cycling is not allowed and the cyclist will have to push/carry their bicycle.

Two changes:

1. Cycling segments will now use those sections (but will avoid them and only do so if no other route around them makes sense)
2. Those sections will be marked with `dismount` in the segment's `street` array, and the segments themselves will have the total `metresDismount` in them.

Our recommendation: Update your UIs so that they display these parts however it makes sense (e.g., colour them red or replace lines with dots or dashes) to indicate to your users that they can't cycle along those sections and will have to dismount.

You can already test this change by using our beta server and planning routes across Sydney, AU: Use https://bigbang.skedgo.com/satapp-beta/ rather than https://api.tripgo.com/v1/

Note, this is a necessary change to enable #84.

(Updated docs related to: https://github.com/skedgo/skedgo-java/pull/828. Also added "metresUnsafe" which was missing in the docs - not related to 828.)