### PR TITLE
dynamic urls

### DIFF
--- a/docs/enterprise/push.md
+++ b/docs/enterprise/push.md
@@ -9,8 +9,8 @@
 We support Push Notifications for both Android (using [Firebase](https://firebase.google.com/docs/notifications/?hl=es)) and iOS (using [APN](https://developer.apple.com/notifications/)) devices. In order to enable and use Push Notifications, the following steps are required:
 
 - Register (only once) in SkedGo backend the corresponding credentials/certificates for each platform (See sections below for details).
-- Each app instance should register itself in the corresponding platform and save the obtained token in SkedGo database, using [data/user/push](https://developer.tripgo.com/specs/push.html#tag/User) endpoint.
-- To send PN to your user, you need to know the user ID on our database and use [data/push](https://developer.tripgo.com/specs/push.html#tag/Push) endpoint, which is filtered by IP address (check with us whether your IP address is whitelisted). 
+- Each app instance should register itself in the corresponding platform and save the obtained token in SkedGo database, using [data/user/push](/specs/push.html#tag/User) endpoint.
+- To send PN to your user, you need to know the user ID on our database and use [data/push](/specs/push.html#tag/Push) endpoint, which is filtered by IP address (check with us whether your IP address is whitelisted). 
 
 
 ## Android
@@ -19,7 +19,7 @@ You need to create your own project in [Firebase](https://console.firebase.googl
 
 For instructions on how to implement Push Notifications in Android, go to [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging).
 
-In short, your app needs to register into FCM to get a token and save it into our database for later usage (see [data/user/push](https://developer.tripgo.com/swagger/?url=https://raw.githubusercontent.com/skedgo/tripgo-api/gh-pages/specs/pn.swagger.yaml) endpoint). Note that this token may change, any time that happens you need to save it again in the database.
+In short, your app needs to register into FCM to get a token and save it into our database for later usage (see [data/user/push](/swagger/?url=https://raw.githubusercontent.com/skedgo/tripgo-api/gh-pages/specs/pn.swagger.yaml) endpoint). Note that this token may change, any time that happens you need to save it again in the database.
 
 
 ## iOS
@@ -28,7 +28,7 @@ You need to configure your app for APN, follow instructions [from Apple](http://
 
 For instructions on how to implement Push Notifications in iOS, go to [Configuring Remote Notification](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/HandlingRemoteNotifications.html#//apple_ref/doc/uid/TP40008194-CH6-SW4).
 
-In short, your app needs to register into APN to get a token and save it into our database for later usage (see [data/user/push](https://developer.tripgo.com/specs/push.html#tag/User) endpoint). Note that this token may change, any time that happens you need to save it again in the database. The token returned by the iOS SDK will be a binary data object, while our backend expends a string. To turn the data into a string, use this snipped:
+In short, your app needs to register into APN to get a token and save it into our database for later usage (see [data/user/push](/specs/push.html#tag/User) endpoint). Note that this token may change, any time that happens you need to save it again in the database. The token returned by the iOS SDK will be a binary data object, while our backend expends a string. To turn the data into a string, use this snipped:
 
 ```swift
 let tokenString = tokenData.reduce(into: "") { $0.append(String(format: "%02X", $1)) }
@@ -39,6 +39,6 @@ When receiving push notifications, additional fields that were provide in the `d
 
 ## Sending PN
 
-If you want to send PN to your users, you first need to have your server/s IP/s address/es whitelisted in our platform. Then, you can use [data/push](https://developer.tripgo.com/specs/push.html#tag/Push) endpoint to send notifications to a list of users (by their userID).
+If you want to send PN to your users, you first need to have your server/s IP/s address/es whitelisted in our platform. Then, you can use [data/push](/specs/push.html#tag/Push) endpoint to send notifications to a list of users (by their userID).
 
 Notifications that we send support a title, message, sound and badge, with a ttl (time to live) value, as well as custom `data` which will be passed on to your apps. Be mindful of size limits imposed by Firebase or APN.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ One note of causion: Some text, such as line names and status alerts, is provide
 
 Our API splits the world into several pieces, which we call regions. Several endpoints require you to pass along a region code, e.g., because identifiers might be duplicated around the world.
 
-You can get a list of regions by quering [`regions.json`](https://developer.tripgo.com/#tag/Configuration%2Fpaths%2F~1regions.json%2Fpost):
+You can get a list of regions by quering [`regions.json`](/#tag/Configuration%2Fpaths%2F~1regions.json%2Fpost):
 
 ```
 curl 'https://api.tripgo.com/v1/regions.json' -H 'Accept: application/json' --compressed -H "X-TripGo-Key: $tripgoKey" -d '{"v":2}'

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Once you have an API key, send it along with every request as the `X-TripGo-Key`
 
 ### 2. Make a request
 
-Our API can do a lot more than just [directions](https://developer.tripgo.com/#tag/Routing%2Fpaths%2F~1routing.json%2Fget), but if that is what you are interested in, then try something like:
+Our API can do a lot more than just [directions](/#tag/Routing%2Fpaths%2F~1routing.json%2Fget), but if that is what you are interested in, then try something like:
 
 ```
 curl 'https://api.tripgo.com/v1/routing.json?from=(-33.859,151.207)&to=(-33.863,151.208)&departAfter=1532799914&modes[]=wa_wal&v=11&locale=en' -H 'Accept: application/json' --compressed -H "X-TripGo-Key: $tripgoKey" -g
@@ -37,7 +37,7 @@ Keep in mind that this API is optimised to return a large number of trip results
 
 2. If you're a web developer, take a look at [our **sample app** "FastGo"](https://github.com/skedgo/fastgo-react-native) and its accompanying [blog post series](https://skedgo.com/en/fastgo-tripgo-api-sample-app-using-react-native-part-1/), or check out our [Leaflet Plugin](https://github.com/skedgo/leaflet.tripgo.routing) (see [Demo](https://skedgo.github.io/leaflet.tripgo.routing/)).
 
-3. If you're a backend developer, dive into the [**API specs**](https://developer.tripgo.com/specs), which are available in OpenAPI (formerly Swagger) format. <!-- 4. Continue reading with our [in-depth **guides**](guides). -->
+3. If you're a backend developer, dive into the [**API specs**](/specs), which are available in OpenAPI (formerly Swagger) format. <!-- 4. Continue reading with our [in-depth **guides**](guides). -->
 
 4. If you know how to debug a web app, look at the network activity for [our web app](https://tripgo.com/) to get an idea of which API calls to use when.  (Filter for "satapp".)
 

--- a/docs/specs/account.swagger.yaml
+++ b/docs/specs/account.swagger.yaml
@@ -13,7 +13,7 @@ info:
   version: 1.0.0
   title: Account Management
   x-logo:
-    url: "https://developer.tripgo.com/img/tripgo-api-logo-color.svg"
+    url: "/img/tripgo-api-logo-color.svg"
 basePath: '/account'
 tags:
   - name: Basic Auth
@@ -36,40 +36,40 @@ x-tagGroups:
 
 paths:
   /login:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/login"
+    $ref: "/specs/modules/account.paths.yaml#/login"
   /logout:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/logout"
+    $ref: "/specs/modules/account.paths.yaml#/logout"
   '/reset/{email}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/reset-{email}"
+    $ref: "/specs/modules/account.paths.yaml#/reset-{email}"
   '/validate/reset/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/validate-reset-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/validate-reset-{token}"
   /password/change:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/password-change"
+    $ref: "/specs/modules/account.paths.yaml#/password-change"
   '/password/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/password-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/password-{token}"
   /password/validate:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/password-validate"
+    $ref: "/specs/modules/account.paths.yaml#/password-validate"
   /signup:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/signup"
+    $ref: "/specs/modules/account.paths.yaml#/signup"
   '/validate/signup/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/validate-signup-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/validate-signup-{token}"
   /alias:
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/alias"
+    $ref: "/specs/modules/account.paths.yaml#/alias"
   '/alias/{email}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/alias-{email}"
+    $ref: "/specs/modules/account.paths.yaml#/alias-{email}"
   '/alias/primary/{email}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/alias-primary-{email}"
+    $ref: "/specs/modules/account.paths.yaml#/alias-primary-{email}"
   '/alias/validate/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/alias-validate-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/alias-validate-{token}"
   '/android/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/android-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/android-{token}"
   '/apple/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/apple-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/apple-{token}"
   '/google/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/google-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/google-{token}"
   '/facebook/{token}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/facebook-{token}"
+    $ref: "/specs/modules/account.paths.yaml#/facebook-{token}"
   '/twitter/{token}/{secret}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/twitter-{token}-{secret}"
+    $ref: "/specs/modules/account.paths.yaml#/twitter-{token}-{secret}"
   '/twitter_callback/{oauthToken}/{verifier}':
-    $ref: "https://developer.tripgo.com/specs/modules/account.paths.yaml#/twitter_callback-{oauthToken}-{verifier}"
+    $ref: "/specs/modules/account.paths.yaml#/twitter_callback-{oauthToken}-{verifier}"

--- a/docs/specs/bookings.swagger.yaml
+++ b/docs/specs/bookings.swagger.yaml
@@ -3,7 +3,7 @@ info:
   version: 1.11.0
   title: TripGo
   x-logo:
-    url: "https://developer.tripgo.com/img/tripgo-api-logo-color.svg"
+    url: "/img/tripgo-api-logo-color.svg"
   description:
     The TripGo API, for selected providers, allows users to book and pay
     for transport.<br/>
@@ -38,44 +38,44 @@ tags:
 
 paths:
   /auth/{region}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/auth-{region}"
+    $ref: "/specs/modules/booking.paths.yaml#/auth-{region}"
   /auth/{provider}/signin:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/auth-{provider}-signin"
+    $ref: "/specs/modules/booking.paths.yaml#/auth-{provider}-signin"
   /auth/signin/{instanceID}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/auth-signin-{instanceID}"
+    $ref: "/specs/modules/booking.paths.yaml#/auth-signin-{instanceID}"
   /auth/{provider}/logout:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/auth-{provider}-logout"
+    $ref: "/specs/modules/booking.paths.yaml#/auth-{provider}-logout"
   /booking/{tripID}/{segmentID}/info:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{tripID}-{segmentID}-info"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{tripID}-{segmentID}-info"
   /booking/{version}/{tripID}/{segmentID}/book:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-book"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-book"
   /booking/{version}/{tripID}/{segmentID}/book/{step}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-book-{step}"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-book-{step}"
   /booking/{version}/{tripID}/{segmentID}/payment:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-payment"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-payment"
   /booking/{version}/{tripID}/{segmentID}/confirm:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-confirm"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-confirm"
   /booking/{version}/{token}/status:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-status"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-status"
   /booking/{version}/{token}/cancel:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-cancel"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-cancel"
   /booking/{version}/{token}/rate:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-rate"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-rate"
   /booking/{version}/{token}/update:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-update"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-update"
   /booking/{version}/{token}/pay.html:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-pay.html"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-pay.html"
   /booking/{version}/{token}/pay:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{token}-pay"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{token}-pay"
   /booking/{version}/{tripID}/{segmentID}/quick:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-quick"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-quick"
   /booking/{version}/{tripID}/{segmentID}/quick/{serviceID}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-quick-{serviceID}"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-quick-{serviceID}"
   /booking/{version}/{tripID}/{segmentID}/update/{serviceID}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-update-{serviceID}"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-update-{serviceID}"
   /booking/{version}/{tripID}/{segmentID}/details/{quoteId}:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-details-{quoteId}"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-{version}-{tripID}-{segmentID}-details-{quoteId}"
   /booking:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking"
+    $ref: "/specs/modules/booking.paths.yaml#/booking"
   /booking/valid/count:
-    $ref: "https://developer.tripgo.com/specs/modules/booking.paths.yaml#/booking-valid-count"
+    $ref: "/specs/modules/booking.paths.yaml#/booking-valid-count"

--- a/docs/specs/modules/account.definitions.yaml
+++ b/docs/specs/modules/account.definitions.yaml
@@ -26,7 +26,7 @@ json_jsonaliases:
     aliases:
       type: array
       items:
-        $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonalias'
+        $ref: '/specs/modules/account.definitions.yaml#/json_jsonalias'
   description: List of email aliases
 json_jsonlocation:
   type: object
@@ -45,7 +45,7 @@ json_jsonnewpassword:
   type: object
   title: JsonNewPassword
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonuser'
+    - $ref: '/specs/modules/account.definitions.yaml#/json_jsonuser'
     - properties:
         newPassword:
           type: string
@@ -54,10 +54,10 @@ json_jsonsignupuser:
   type: object
   title: JsonSignupUser
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonuser'
+    - $ref: '/specs/modules/account.definitions.yaml#/json_jsonuser'
     - properties:
         location:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonlocation'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonlocation'
         name:
           type: string
   description: User Sign Up data

--- a/docs/specs/modules/account.paths.yaml
+++ b/docs/specs/modules/account.paths.yaml
@@ -17,17 +17,17 @@
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       '401':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Authentication Failed.
       default:
@@ -51,12 +51,12 @@
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -79,7 +79,7 @@
     responses:
       '200':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonalias'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonalias'
         headers: {}
         description: Success
       default:
@@ -103,17 +103,17 @@
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       '401':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Authentication Failed.
       default:
@@ -135,7 +135,7 @@
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       default:
@@ -153,7 +153,7 @@ alias:
     responses:
       '200':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonaliases'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonaliases'
         headers: {}
         description: Success
       default:
@@ -183,12 +183,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -213,12 +213,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -243,12 +243,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -273,12 +273,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -303,12 +303,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -337,12 +337,12 @@ alias:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -362,17 +362,17 @@ password-validate:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonuser'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonuser'
         description: 'plain password (username can be null, will be ignored)'
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -395,12 +395,12 @@ password-validate:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -422,17 +422,17 @@ signup:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonsignupuser'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonsignupuser'
         description: 'user data, including (optionally) password, name and home.'
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -454,19 +454,19 @@ password-change:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonnewpassword'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonnewpassword'
         description: >-
           current and new plain passwords (username can be null, will be
           ignored)
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -489,12 +489,12 @@ password-change:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -519,12 +519,12 @@ password-change:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:
@@ -544,22 +544,22 @@ login:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonuser'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonuser'
         description: user data including username and password
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       '401':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Authentication Failed.
       default:
@@ -577,17 +577,17 @@ logout:
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       '401':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Authentication Failed.
       default:
@@ -614,17 +614,17 @@ logout:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_jsonuser'
+          $ref: '/specs/modules/account.definitions.yaml#/json_jsonuser'
         description: 'new plain password (username can be null, will be ignored)'
     responses:
       '201':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Success
       '400':
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/account.definitions.yaml#/json_apiresult'
+          $ref: '/specs/modules/account.definitions.yaml#/json_apiresult'
         headers: {}
         description: Missing or invalid parameters.
       default:

--- a/docs/specs/modules/booking.definitions.yaml
+++ b/docs/specs/modules/booking.definitions.yaml
@@ -6,14 +6,14 @@ BookingsCountResponse:
 BookingsResponse:
   properties:
     bookings:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/ConfirmedBookingData'
+      $ref: '/specs/modules/booking.definitions.yaml#/ConfirmedBookingData'
     count:
       type: number
 
 ConfirmedBookingData:
   properties:
     confirmation:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/LocalizedBookingConfirmationInfo'
+      $ref: '/specs/modules/booking.definitions.yaml#/LocalizedBookingConfirmationInfo'
     trips:
       type: array
       items:
@@ -28,17 +28,17 @@ ConfirmedBookingData:
 LocalizedBookingConfirmationInfo:
   properties:
     provider:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Detail'
+      $ref: '/specs/modules/booking.definitions.yaml#/Detail'
     vehicle:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Detail'
+      $ref: '/specs/modules/booking.definitions.yaml#/Detail'
     status:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Detail'
+      $ref: '/specs/modules/booking.definitions.yaml#/Detail'
     purchase:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Purchase'
+      $ref: '/specs/modules/booking.definitions.yaml#/Purchase'
     actions:
       type: array
       items:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Action'
+        $ref: '/specs/modules/booking.definitions.yaml#/Action'
 
 Detail:
   properties:
@@ -75,9 +75,9 @@ Purchase:
     valid:
       type: boolean
     brand:
-      $ref: 'https://developer.tripgo.com/specs/tripgo.swagger.yaml#/definitions/CompanyInfo'
+      $ref: '/specs/tripgo.swagger.yaml#/definitions/CompanyInfo'
     source:
-      $ref: 'https://developer.tripgo.com/specs/tripgo.swagger.yaml#/definitions/DataSourceAttribution'
+      $ref: '/specs/tripgo.swagger.yaml#/definitions/DataSourceAttribution'
 
 Action:
   properties:
@@ -117,7 +117,7 @@ AuthData:
     modeIdentifier:
       type: string
     companyInfo:
-      $ref: 'https://developer.tripgo.com/specs/tripgo.swagger.yaml#/definitions/CompanyInfo'
+      $ref: '/specs/tripgo.swagger.yaml#/definitions/CompanyInfo'
 
 BookingAction:
   type: object
@@ -144,14 +144,14 @@ BookingAction:
 BookingForm:
   properties:
     action:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingAction'
+      $ref: '/specs/modules/booking.definitions.yaml#/BookingAction'
     prevAction:
-      $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingAction'
+      $ref: '/specs/modules/booking.definitions.yaml#/BookingAction'
     form:
       description: The list of FormGroups to show in the form.
       type: array
       items:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormGroup'
+        $ref: '/specs/modules/booking.definitions.yaml#/FormGroup'
     image:
       description: 'a URL of an image to show, whenever available'
       type: string
@@ -177,25 +177,25 @@ BookingForm:
 
 PaymentForm:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+    - $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
     - type: object
   description: Generic data to generate input fields on a payment booking screen
 
 AuthForm:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+    - $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
     - type: object
   description: Generic data to generate input fields on an auth booking screen
 
 BookingFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         action:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingAction'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingAction'
         prevAction:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingAction'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingAction'
         form:
           description: The list of FormGroups to show in the form, not described properly on purpose to avoid infinite loop
           type: array
@@ -225,7 +225,7 @@ BookingFormData:
       description: ''
       type: array
       items:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+        $ref: '/specs/modules/booking.definitions.yaml#/FormField'
   description: ''
 
 FormField:
@@ -281,7 +281,7 @@ FormField:
 
 StringFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -301,16 +301,16 @@ StringFormField:
 
 AddressFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
           description: 'value of the field, to be shown and filled/updated by the user, and sent to the backend if required'
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/Location'
+          $ref: '/specs/modules/booking.definitions.yaml#/Location'
 
 DateTimeFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -321,7 +321,7 @@ DateTimeFormField:
 
 StepperFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -336,7 +336,7 @@ StepperFormField:
 
 TimeFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -345,7 +345,7 @@ TimeFormField:
 
 PasswordFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -354,7 +354,7 @@ PasswordFormField:
 
 LinkFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -370,7 +370,7 @@ LinkFormField:
 
 TextFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -379,7 +379,7 @@ TextFormField:
 
 SwitchFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -388,16 +388,16 @@ SwitchFormField:
 
 OptionFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
           description: 'value of the field, to be shown and filled/updated by the user, and sent to the backend if required'
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/OptionData'
+          $ref: '/specs/modules/booking.definitions.yaml#/OptionData'
         allValues:
           description: 'list of available values to show to the user'
           items:
-            $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/OptionData'
+            $ref: '/specs/modules/booking.definitions.yaml#/OptionData'
 
 OptionData:
   properties:
@@ -416,7 +416,7 @@ OptionData:
 
 ExternalFormField:
   allOf:
-    - $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+    - $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     - type: object
     - properties:
         value:
@@ -438,7 +438,7 @@ FormGroup:
       description: ''
       type: array
       items:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/FormField'
+        $ref: '/specs/modules/booking.definitions.yaml#/FormField'
     footer:
       description: ''
       type: string

--- a/docs/specs/modules/booking.paths.yaml
+++ b/docs/specs/modules/booking.paths.yaml
@@ -39,7 +39,7 @@ auth-{region}:
           description: ''
           type: array
           items:
-            $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/AuthData'
+            $ref: '/specs/modules/booking.definitions.yaml#/AuthData'
         headers: {}
         description: Success
       default:
@@ -76,7 +76,7 @@ auth-{provider}-signin:
     responses:
       200:
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
         headers: {}
         description: Success
       default:
@@ -101,12 +101,12 @@ auth-signin-{instanceID}:
       - name: body
         in: body
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
         description: sent from the client to be processed by the backend
     responses:
       201:
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
         headers: {}
         description: Success
       default:
@@ -180,7 +180,7 @@ booking-{tripID}-{segmentID}-info:
     responses:
       200:
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
         description: Successful response
 
 booking-{version}-{tripID}-{segmentID}-book:
@@ -208,12 +208,12 @@ booking-{version}-{tripID}-{segmentID}-book:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
   parameters:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
 
@@ -248,12 +248,12 @@ booking-{version}-{tripID}-{segmentID}-book-{step}:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
   parameters:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
   get:
@@ -285,7 +285,7 @@ booking-{version}-{tripID}-{segmentID}-book-{step}:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
 
 booking-{version}-{tripID}-{segmentID}-payment:
   post:
@@ -312,12 +312,12 @@ booking-{version}-{tripID}-{segmentID}-payment:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/PaymentForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/PaymentForm'
   parameters:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
 
@@ -346,13 +346,13 @@ booking-{version}-{tripID}-{segmentID}-confirm:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
 
   parameters:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
 
@@ -376,7 +376,7 @@ booking-{version}-{token}-status:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
 
 booking-{version}-{token}-cancel:
   post:
@@ -398,12 +398,12 @@ booking-{version}-{token}-cancel:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
   parameters:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
 
@@ -426,7 +426,7 @@ booking-{version}-{token}-cancel:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
 
 booking-{version}-{token}-rate:
   get:
@@ -448,7 +448,7 @@ booking-{version}-{token}-rate:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
   post:
     tags:
       - Form-Based Booking
@@ -473,7 +473,7 @@ booking-{version}-{token}-rate:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingFormData'
+        $ref: '/specs/modules/booking.definitions.yaml#/BookingFormData'
       required: true
       description: Identifier of booking as returned by previous server call.
 
@@ -498,7 +498,7 @@ booking-{version}-{token}-update:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/tripgo.swagger.yaml#/definitions/RoutingResponse'
+          $ref: '/specs/tripgo.swagger.yaml#/definitions/RoutingResponse'
 
 booking-{version}-{token}-pay.html:
   get:
@@ -582,7 +582,7 @@ booking-{version}-{token}-pay:
       200:
         description: returns token for in app payment
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/PaymentToken'
+          $ref: '/specs/modules/booking.definitions.yaml#/PaymentToken'
   post:
     tags:
       - Form-Based Booking
@@ -609,7 +609,7 @@ booking-{version}-{token}-pay:
     - name: input
       in: body
       schema:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/PaymentData'
+        $ref: '/specs/modules/booking.definitions.yaml#/PaymentData'
       required: true
 
 
@@ -651,7 +651,7 @@ booking-{version}-{tripID}-{segmentID}-quick:
         schema:
           type: array
           items:
-            $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/LocalizedQuickBookingInfo'
+            $ref: '/specs/modules/booking.definitions.yaml#/LocalizedQuickBookingInfo'
 
 booking-{version}-{tripID}-{segmentID}-quick-{serviceID}:
   get:
@@ -689,11 +689,11 @@ booking-{version}-{tripID}-{segmentID}-quick-{serviceID}:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
       201:
         description: (200) in case of missing userToken, errorCode will be 444, so the app can trigger silent log in or signup
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/ErrorMessage'
+          $ref: '/specs/modules/booking.definitions.yaml#/ErrorMessage'
         examples:
           application/json:
             {
@@ -734,7 +734,7 @@ booking-{version}-{tripID}-{segmentID}-update-{serviceID}:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/tripgo.swagger.yaml#/definitions/RoutingResponse'
+          $ref: '/specs/tripgo.swagger.yaml#/definitions/RoutingResponse'
 
 booking-{version}-{tripID}-{segmentID}-details-{quoteId}:
   get:
@@ -767,7 +767,7 @@ booking-{version}-{tripID}-{segmentID}-details-{quoteId}:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingForm'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingForm'
 
 booking:
   get:
@@ -800,11 +800,11 @@ booking:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingsResponse'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingsResponse'
       201:
         description: (200) in case of missing userToken, errorCode will be 444, so the app can trigger silent log in or signup
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/ErrorMessage'
+          $ref: '/specs/modules/booking.definitions.yaml#/ErrorMessage'
         examples:
           application/json:
             {
@@ -828,11 +828,11 @@ booking-valid-count:
       200:
         description: Successful response
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/BookingsCountResponse'
+          $ref: '/specs/modules/booking.definitions.yaml#/BookingsCountResponse'
       201:
         description: (200) in case of missing userToken, errorCode will be 444, so the app can trigger silent log in or signup
         schema:
-          $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/ErrorMessage'
+          $ref: '/specs/modules/booking.definitions.yaml#/ErrorMessage'
         examples:
           application/json:
             {

--- a/docs/specs/pn.swagger.yaml
+++ b/docs/specs/pn.swagger.yaml
@@ -3,7 +3,7 @@ info:
   version: 1.0.0
   title: Push Notifications
   x-logo:
-    url: "https://developer.tripgo.com/img/tripgo-api-logo-color.svg"
+    url: "/img/tripgo-api-logo-color.svg"
   description: Endpoint for push notifications, there are two groups of endpoints
 
       - adding/removing devices to a specific user

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3,7 +3,7 @@ info:
   version: 1.11.0
   title: TripGo
   x-logo:
-    url: "https://developer.tripgo.com/img/tripgo-api-logo-color.svg"
+    url: "/img/tripgo-api-logo-color.svg"
   description:
     The TripGo API allows you to plan door-to-door trips using
     a large variety of public and private transport. It integrates real-time
@@ -109,7 +109,7 @@ paths:
                 type: array
                 items:
                   type: string
-                description: Public transit modes (pt_pub_*) for which results should be returned. [Mode identifier](https://developer.tripgo.com/faq/#mode-identifiers) strings like `pt_pub` or `pt_pub_subway`. In absence, all modes are included.
+                description: Public transit modes (pt_pub_*) for which results should be returned. [Mode identifier](/faq/#mode-identifiers) strings like `pt_pub` or `pt_pub_subway`. In absence, all modes are included.
               operatorIDs:
                 type: array
                 items:
@@ -222,7 +222,7 @@ paths:
                 type: array
                 items:
                   type: string
-                description: Public transit modes (pt_pub_*) for which results should be returned. [Mode identifier](https://developer.tripgo.com/faq/#mode-identifiers) strings like `pt_pub` or `pt_pub_subway`. In absence, all modes are included.
+                description: Public transit modes (pt_pub_*) for which results should be returned. [Mode identifier](/faq/#mode-identifiers) strings like `pt_pub` or `pt_pub_subway`. In absence, all modes are included.
               routesIDs:
                 type: array
                 items:
@@ -454,7 +454,7 @@ paths:
           items:
             type: string
           description:
-            Modes for which results should be returned. [Mode identifier](https://developer.tripgo.com/faq/#mode-identifiers) strings like `pt_pub` or `pt_tax_FLITWAYS` exactly as returned by `regions.json`. If multiple modes are specified only trips which mix at least two of these modes are returned. [Details of single-modal and multi-modal queries are on our developer site](https://developer.tripgo.com/faq/#single-modal-vs-multi-modal-routing).
+            Modes for which results should be returned. [Mode identifier](/faq/#mode-identifiers) strings like `pt_pub` or `pt_tax_FLITWAYS` exactly as returned by `regions.json`. If multiple modes are specified only trips which mix at least two of these modes are returned. [Details of single-modal and multi-modal queries are on our developer site](/faq/#single-modal-vs-multi-modal-routing).
           required: true
         - name: avoidModes
           type: array
@@ -1008,10 +1008,10 @@ paths:
       description: |
         Gets points of interest for a provided map region. Which POIs are included depends on the enabled modes (by default public transport only). For public transport, transit stops are displayed; for driving, car parks; for bike share, bike share pods; for car share, car share locations; etc.
 
-        This variant using cell IDs is recommended if the client wants to cache locations locally, while frequently calling this endpoint to make sure the local data is update without requiring a lot of data overhead (and having most of the logic on the server). For an explanation, [please see our developer site](https://developer.tripgo.com/faq#locations-cell-ids-and-hash-codes).
+        This variant using cell IDs is recommended if the client wants to cache locations locally, while frequently calling this endpoint to make sure the local data is update without requiring a lot of data overhead (and having most of the logic on the server). For an explanation, [please see our developer site](/faq#locations-cell-ids-and-hash-codes).
       externalDocs:
         description: Locations, cell IDs and hash codes
-        url: "https://developer.tripgo.com/faq/#locations-cell-ids-and-hash-codes"
+        url: "/faq/#locations-cell-ids-and-hash-codes"
       parameters:
         - name: input
           in: body
@@ -1412,7 +1412,7 @@ definitions:
         type: object
         properties:
           $modeIdentifier:
-            description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+            description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See /faq/#mode-identifiers.
             $ref: '#/definitions/ModeIdentifier'
 
   RegionInfoInput:
@@ -1612,7 +1612,7 @@ definitions:
         type: string
         description: ID of the product in externalActions (currently only used for Uber and Lyft)
       confirmation:
-        $ref: 'https://developer.tripgo.com/specs/modules/booking.definitions.yaml#/LocalizedBookingConfirmationInfo'
+        $ref: '/specs/modules/booking.definitions.yaml#/LocalizedBookingConfirmationInfo'
     required:
       - title
 
@@ -2034,7 +2034,7 @@ definitions:
       - localIcon
 
   ModeIdentifier:
-    description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+    description: This is a map/dictionary with multiple items of this type. Each key is a mode identifier. See /faq/#mode-identifiers.
     properties:
       title:
         type: string
@@ -2052,7 +2052,7 @@ definitions:
       - title
 
   ModeDetails:
-    description: This is a map/dictionary with multiple items of this type. Each key is a generic mode identifier. See https://developer.tripgo.com/faq/#mode-identifiers.
+    description: This is a map/dictionary with multiple items of this type. Each key is a generic mode identifier. See /faq/#mode-identifiers.
     properties:
       title:
         type: string
@@ -2473,7 +2473,7 @@ definitions:
           List of mode identifiers that are available in this region (but not necessarily everywhere in that region).
           Look at `modes` array in `regions.json` to get more details on each mode. These are also the modes that can be
            used as input to any routing endpoint. See
-           https://developer.tripgo.com/faq/#mode-identifiers.
+           /faq/#mode-identifiers.
         items:
           type: string
       urls:
@@ -3120,7 +3120,7 @@ definitions:
       <br/>
       The available fields heavily depend on the type of the segment. E.g., stationary segments have `location`, while others have both `from` and `to`.<br/>
       <br/>
-      Many of the strings fields have placeholder, such as `<PLATFORM>` that should be filled in with information from the reference. [See documentation](https://developer.tripgo.com/faq/#placeholders-in-segment-templates) on those templates.
+      Many of the strings fields have placeholder, such as `<PLATFORM>` that should be filled in with information from the reference. [See documentation](/faq/#placeholders-in-segment-templates) on those templates.
     properties:
       hashCode:
         type: integer
@@ -3131,7 +3131,7 @@ definitions:
         type: string
         description:
           Mode identifier. Will match input, e.g., `routing.json`'s `modes`. See
-          https://developer.tripgo.com/faq/#mode-identifiers.
+          /faq/#mode-identifiers.
       availability:
         type: string
         description: Indicates availability of the segment, e.g., if it's too late to book this segment for the requested departure time, or if a scheduled service has been cancelled.

--- a/docs/specs/user.swagger.json
+++ b/docs/specs/user.swagger.json
@@ -2964,7 +2964,7 @@
       "in": "header"
     },
     "User Token": {
-      "description": "Identifies your user, use https://developer.tripgo.com/specs/userAuth to get this userToken",
+      "description": "Identifies your user, use /specs/userAuth to get this userToken",
       "type": "apiKey",
       "name": "userToken",
       "in": "header"

--- a/docs/swagger/index.html
+++ b/docs/swagger/index.html
@@ -71,7 +71,7 @@
 window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "https://developer.tripgo.com/specs/tripgo.swagger.yaml",
+    url: "/specs/tripgo.swagger.yaml",
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
removing hardcoded urls so we can deploy the specs both in:

- https://developer.tripgo.com/
- https://developer-beta.tripgo.com/ (beta only)

@nighthawk wdyt of having a beta/dev only specs/docs site?