### PR TITLE
working on documentation-enhancement issues: issue #122 has`realTimeS…

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3125,6 +3125,15 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/NearbyCarParkLocation'
+      realTimeStatus:
+        type: string
+        description: |
+          **Deprecated since v11.** Indicator for whether real-time information is available for this service. Note that even if this says the service is real-time, this does not mean the `startTime` is real-time.
+        deprecated: true
+        enum:
+          - IS_REAL_TIME
+          - CAPABLE
+          - INCAPABLE
 
     required:
       - segmentTemplateHashCode


### PR DESCRIPTION
For segment, "realTimeStatus" has been deprecated since v11. 