### PR TITLE
times using integer instead of number

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -606,10 +606,10 @@ paths:
                 type: object
                 properties:
                   startTime:
-                    type: number
+                    type: integer
                     description: Start of the time period in seconds since 1970
                   endTime:
-                    type: number
+                    type: integer
                     description: End of the time period in seconds since 1970
                 required:
                   - startTime
@@ -1404,7 +1404,7 @@ definitions:
     type: object
     properties:
       v:
-        type: number
+        type: integer
         format: int32
         description: Version number
         minimum: 2
@@ -1536,10 +1536,10 @@ definitions:
         type: string
         description: Arbitrary identifier for this input item. The output will refer back to this.
       startTime:
-        type: number
+        type: integer
         description: Start time in seconds since 1970
       endTime:
-        type: number
+        type: integer
         description: End time in seconds since 1970
     required:
       - class
@@ -1555,7 +1555,7 @@ definitions:
         location:
           $ref: '#/definitions/Coordinate'
         priority:
-          type: number
+          type: integer
           description: The priority of this event, used for handling clashes.
             To give an event a higher priority, assign it a higher value.
             Typical values are 9 for the user's current location (i.e., the
@@ -2223,7 +2223,7 @@ definitions:
             price:
               type: number
             maxDurationInMinutes:
-              type: number
+              type: integer
               description: maximun duration for this price in minutes
           required:
             - price
@@ -2254,7 +2254,7 @@ definitions:
     properties:
       maxStayInMinutes:
         description: Maximun stay time in minutes
-        type: number
+        type: integer
       noRestrictionWhenClosed:
         description: If this is `true`, the restrictions applies only during the time zone defined in `openingHours`
         type: boolean


### PR DESCRIPTION
This PR switches all times (and other fields that also apply) to use integer instead of number, to be consistent.