### PR TITLE
Documented new fields related to micro-mobility modes

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2206,6 +2206,9 @@ definitions:
       remoteDarkIcon:
         description: Part of icon file name for dark background that can be  fetched from server.
         type: string
+      remoteIconIsBranding:
+        description: Whether the remote icon is a representing the brand not the mode. If this is `true` it's a good idea to show the brand icon plus an icon indicating the mode.
+        type: boolean
       remoteIconIsTemplate:
         description: Whether the remote icon is a template, i.e., whether apps can ignore the colour information of the image and instead apply a tint colour.
         type: boolean
@@ -2220,6 +2223,9 @@ definitions:
     properties:
       title:
         type: string
+      subtitle:
+        type: string
+        description: Optional subtitle indicating what kind of mode this is, e.g., if title is 'Uber' this might side 'Ride-hailing'
       URL:
         type: string
       color:
@@ -2264,6 +2270,13 @@ definitions:
         type: string
       modeInfo:
         $ref: '#/definitions/ModeInfo'
+      modeImageNames:
+        description: >
+          A list of local icons (like in `ModeInfo.localIcon`) representing the modes provided by the company which 
+          this mode is representing. E.g., a micro-mobility company might provide both scooter and e-bikes.
+        type: array
+        items:
+          type: string
       operators:
         description: List of public operators names, see `operators` field
         type: array


### PR DESCRIPTION
- Added `ModeInfo.remoteIconIsBranding`
- Added `ModeIdentifier.subtitle`
- Added `SpecificModeDetails.modeImageNames`

These will be added with https://github.com/skedgo/skedgo-java/pull/1463