### PR TITLE
Stationary identifiers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,6 +70,7 @@ The syntax of the mode string is like this:
 * `cy_` is for cycling
 * `wa_` is for walking
 * `in_` is for intercity long distance transport
+* `stationary_` is for stationary segments in between transport segments
 
 #### `pt_`
 
@@ -102,6 +103,17 @@ The syntax of the mode string is like this:
 * `me_car-r` is for car rental (like Budget)
 * `me_car-p` is for car pooling (like BlaBlaCar)
 * `me_mot` is for your own motorbike
+
+#### `stationary_`
+
+* `stationary_parking-onstreet` is for parking a vehicle on-street
+* `stationary_parking-offstreet` is for parking a vehicle in an off-street location
+* `stationary_wait` is a buffer for waiting for the following transport, e.g., waiting for a taxi or ride share to show up, but *not* for transferring between timetable-based public transport segments which get the special identifier below.
+* `stationary_transfer` is for transferring between timetable-based public transport segments, often following a walk; note: you only get this if there are at least two public transport segments in a trip.
+* `stationary_vehicle-collect` is for picking up a shared vehicle
+* `stationary_vehicle-return` is for returning a shared vehicle
+* `stationary_airport-checkin` is for checking in at an airport
+* `stationary_airport-checkout` is for "checking out" off an airport, e.g., for picking up luggage and going through immigration
 
 ---
 

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -2197,7 +2197,7 @@ definitions:
     properties:
       identifier:
         description: |
-          Typically a mode-identifier, but it can be more specific that the one from the query, e.g., `pt_pub_bus` even though the query requested `pt_pub`. Missing for stationary segments.
+          Typically a mode-identifier, but it can be more specific that the one from the query, e.g., `pt_pub_bus` even though the query requested `pt_pub`. Stationary segments have identifiers starting with `stationary_`.
         type: string
       alt:
         description: Textual alternative to icon
@@ -2220,6 +2220,7 @@ definitions:
       color:
         $ref: '#/definitions/Color'
     required:
+      - identifier
       - alt
       - localIcon
 


### PR DESCRIPTION
This updates the documentation for a recent change to the TripGo API:

- ModeInfo.identifier is no longer optional
- Documentation of `stationary_` identifiers