### PR TITLE
Swagger cleanup

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -1372,21 +1372,6 @@ paths:
             required:
               - embarkationStops
 
-  /arrivals.json:
-    post:
-      tags:
-        - Stops
-      summary: Arrival timetable for stop
-      description:
-        Gets the arrival timetable for a provided transit stop by the stop's ID.
-      parameters:
-        - name: DOCUMENTATION_NOT_COMPLETE
-          in: query
-          type: boolean
-      responses:
-        200:
-          description: Successful response
-
   /latest.json:
     post:
       tags:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -1531,13 +1531,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/definitions/RealTimeAlert'
-              bicycleAccessible:
-                type: boolean
-                description: Can you take a bicycle on this service? Missing when unknown.
-              wheelchairAccessible:
-                type: boolean
-                description: |
-                  If this service is wheelchair accessible or not. If this field is missing, this does not mean that it is not accessible, but rather that it is unknown whether it is accessible. Only if the value is present and is `false`, does it mean that the service is not wheelchair accessible.
 
   /alerts/transit.json:
     get:


### PR DESCRIPTION
- Remove `arrivals.json` from specs as that doesn't exist
- Remove two properties from `service.json` from the root level, as they are provided on the shapes level further down instead.