### PR TITLE
Add more ticket/fare related information

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -1872,6 +1872,9 @@ definitions:
         wheelchairAccessible:
           type: boolean
           description: Is this stop wheelchair accessible? Missing when unknown.
+        zoneID:
+          type: string
+          description: Zone ID of the stop. Populated with `zone_id` from GTFS, where available.
         url:
           type: string
           description: URL with more information about this location. Populated with `stop_url`  from GTFS, where available.
@@ -3610,8 +3613,12 @@ definitions:
     - $ref: '#/definitions/BaseSegmentTemplateAnyMoving'
     - type: object
       properties:
-        serviceOperator:
+        operator:
           type: string
+          description: Operator name
+        operatorID:
+          type: string
+          description: Operator ID
         disclaimer:
           type: string
           description: |
@@ -3640,7 +3647,8 @@ definitions:
           type: string
           description: Message to send to `smsNumber` to get real-time information
       required:
-        - serviceOperator
+        - operator
+        - operatorID
 
   SegmentTemplateMovingNonTransit:
     allOf:
@@ -3961,9 +3969,14 @@ definitions:
       name:
         description: Ticket name.
         type: string
+      fareID:
+        description: Fare ID for the ticket, as provided in GTFS
+        type: string
       cost:
         description: Ticket price in user's local currency (optional).
         type: number
       exchange:
         description: Rate to convert cost from user's local currency to dollar (optional).
         type: number
+    required:
+      - name

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3793,9 +3793,12 @@ definitions:
           Same as `moneyCost` but converted to USD using latest
           exchange rate. Useful for comparing trips which us different
           currencies.
+      currency:
+        type: string
+        description: The currency code for the `moneyCost` value, e.g., 'AUD', 'EUR' or 'USD'
       currencySymbol:
         type: string
-        description: The currency symbol for the `moneyCost` value
+        description: The currency symbol for the `moneyCost` value, e.g., '$' for AUD/USD, or '€' for EUR
       weightedScore:
         type: number
         description:


### PR DESCRIPTION
Adds:

- `stop.zoneID`
- `segment.operatorID`
- `ticket.fareID`
- `trip.currency`

Also:

- Remove segment.serviceOperator (still provided, but should use operator)
- Minor optionality / description review