### PR TITLE
Action new input field

### DIFF
--- a/docs/specs/modules/booking.definitions.yaml
+++ b/docs/specs/modules/booking.definitions.yaml
@@ -92,12 +92,15 @@ Action:
         - LOCK
         - UNLOCK
     internalURL:
+      description: "URL to execute the action, usually a GET request, but may require a POST request if input field is not null"
       type: string
     externalURL:
+      description: "external URL to execute the action"
       type: string
     isDestructive:
       type: boolean
     input:
+      description: "if present, the internalURL requires a POST with a JSON object with a field named 'input' and a list of objects with the exact format of these ones, but having the value field completed as expected"
       type: array
       items:
         $ref: '/specs/modules/booking.definitions.yaml#/ActionInput'

--- a/docs/specs/modules/booking.definitions.yaml
+++ b/docs/specs/modules/booking.definitions.yaml
@@ -89,13 +89,30 @@ Action:
         - RATE
         - CALL
         - QRCODE
-        - PAY
+        - LOCK
+        - UNLOCK
     internalURL:
       type: string
     externalURL:
       type: string
     isDestructive:
       type: boolean
+    input:
+      type: array
+      items:
+        $ref: '/specs/modules/booking.definitions.yaml#/ActionInput'
+
+ActionInput:
+  properties:
+    type:
+      enum:
+        - QRCODE
+        - STRING
+        - HIDDEN
+    field:
+      type: string
+    value:
+      type: string
 
 AuthData:
   properties:


### PR DESCRIPTION
Adds input field to action (on confirmed field of booking field for a segment where booking is possible)
If present, the `internalURL` will require a POST instead of a GET to trigger the action.
And an object with a field names `input` is required, with the list of input actions returned.