### PR TITLE
Update API specs and FAQ for new micro-mobility modes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ The syntax of the mode string is like this:
 * `pt_` is for transit which runs on schedules
 * `ps_` is for taxi-like on-demand services
 * `me_` is for vehicles you drive yourself
-* `cy_` is for cycling **Deprecated (use `me_mic&micVehicleType=bicycle` instead)**
+* `cy_` is for cycling **Deprecated (use `me_mic_` instead)**
 * `wa_` is for walking and similar (e.g., wheelchair)
 * `in_` is for intercity long distance transport
 * `stationary_` is for stationary segments in between transport segments
@@ -110,7 +110,11 @@ The syntax of the mode string is like this:
 * `me_car-r` is for car rental (like Budget)
 * `me_car-p` is for car pooling (like BlaBlaCar)
 * `me_mot` is for your own motorbike
-* `me_mic` is for your own micro-mobility (see `micVehicleType` input for `routing.json`)
+* `me_mic` is for your own micro-mobility
+  * `me_mic_bic`, regular bicycle
+  * `me_mic_fbic`, folding/portable bicycle that will be taken on any public transport mode, and will be taken all the way to the destination
+  * `me_mic_esc`, e-scooter up to 25 km/h. Portable, allowed on cycle lanes in general, except specific rules in certain countries
+  * `me_mic_fesc`, e-scooter up to 45 km/h. Portable, not allowed on cycle lanes in general, except specific rules in certain
 
 #### `stationary_`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,10 +111,10 @@ The syntax of the mode string is like this:
 * `me_car-p` is for car pooling (like BlaBlaCar)
 * `me_mot` is for your own motorbike
 * `me_mic` is for your own micro-mobility
-  * `me_mic_bic`, regular bicycle
-  * `me_mic_fbic`, folding/portable bicycle that will be taken on any public transport mode, and will be taken all the way to the destination
-  * `me_mic_esc`, e-scooter up to 25 km/h. Portable, allowed on cycle lanes in general, except specific rules in certain countries
-  * `me_mic_fesc`, e-scooter up to 45 km/h. Portable, not allowed on cycle lanes in general, except specific rules in certain countries
+  * `me_mic_bic`, regular _bic_ycle
+  * `me_mic_fold-bic`, _fold_ing/portable _bic_ycle that will be taken on any public transport mode, and will be taken all the way to the destination
+  * `me_mic_e-sco`, _e-sco_oter up to 25 km/h. Portable, allowed on cycle lanes in general, except specific rules in certain countries
+  * `me_mic_fast-e-sco`, _fast_ _e-sco_oter up to 45 km/h. Portable, not allowed on cycle lanes in general, except specific rules in certain countries
 
 #### `stationary_`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,7 +69,7 @@ The syntax of the mode string is like this:
 * `pt_` is for transit which runs on schedules
 * `ps_` is for taxi-like on-demand services
 * `me_` is for vehicles you drive yourself
-* `cy_` is for cycling
+* `cy_` is for cycling **Deprecated (use `me_mic&micVehicleType=bicycle` instead)**
 * `wa_` is for walking and similar (e.g., wheelchair)
 * `in_` is for intercity long distance transport
 * `stationary_` is for stationary segments in between transport segments
@@ -110,6 +110,7 @@ The syntax of the mode string is like this:
 * `me_car-r` is for car rental (like Budget)
 * `me_car-p` is for car pooling (like BlaBlaCar)
 * `me_mot` is for your own motorbike
+* `me_mic` is for your own micro-mobility (see `micVehicleType` input for `routing.json`)
 
 #### `stationary_`
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,7 +114,7 @@ The syntax of the mode string is like this:
   * `me_mic_bic`, regular bicycle
   * `me_mic_fbic`, folding/portable bicycle that will be taken on any public transport mode, and will be taken all the way to the destination
   * `me_mic_esc`, e-scooter up to 25 km/h. Portable, allowed on cycle lanes in general, except specific rules in certain countries
-  * `me_mic_fesc`, e-scooter up to 45 km/h. Portable, not allowed on cycle lanes in general, except specific rules in certain
+  * `me_mic_fesc`, e-scooter up to 45 km/h. Portable, not allowed on cycle lanes in general, except specific rules in certain countries
 
 #### `stationary_`
 

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -653,27 +653,6 @@ paths:
           in: query
           description: _e_xpected _t_axi/TNC _w_aiting _t_ime, in minutes. This is used for taxis and TNCs where no real-time ETA is available.
           default: 8
-        - name: micVehicleType
-          type: string
-          enum:
-            - bicycle
-            - folding-bicycle
-            - e-scooter
-            - fast-e-scooter
-            - all
-          in: query
-          description: Only applies if `modes` includes `me_mic`, indicating a particular type of micro-mobility<br/>
-            <br/>
-            `bicycle` is a regular bicycle<br/>
-            <br/>
-            `folding-bicycle` is a folding/portable bicycle that will be taken on any public transport mode, and will be taken all the way to the destination, rather than locking it up along the way.<br/>
-            <br/>
-            `e-scooter` is an e-scooter up to 25 km/h. Implications: portable, allowed on cycle lanes in general, except specific rules in certain countries<br/>
-            <br/>
-            `fast-e-scooter` is an e-scooter up to 45 km/h. Implications: portable, not allowed on cycle lanes in general, except specific rules in certain countries<br/>
-            <br/>
-            `all` is to request one trip for each vehicle type described above (picking only one between `bicycle` and `folding-bicycle` according to `fb` parameter).
-          default: all
       responses:
         200:
           description: Successful response. Can include many trips.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -653,6 +653,27 @@ paths:
           in: query
           description: _e_xpected _t_axi/TNC _w_aiting _t_ime, in minutes. This is used for taxis and TNCs where no real-time ETA is available.
           default: 8
+        - name: micVehicleType
+          type: string
+          enum:
+            - bicycle
+            - folding-bicycle
+            - e-scooter
+            - fast-e-scooter
+            - all
+          in: query
+          description: Only applies if `modes` includes `me_mic`, indicating a particular type of micro-mobility<br/>
+            <br/>
+            `bicycle` is a regular bicycle<br/>
+            <br/>
+            `folding-bicycle` is a folding/portable bicycle that will be taken on any public transport mode, and will be taken all the way to the destination, rather than locking it up along the way.<br/>
+            <br/>
+            `e-scooter` is an e-scooter up to 25 km/h. Implications: portable, allowed on cycle lanes in general, except specific rules in certain countries<br/>
+            <br/>
+            `fast-e-scooter` is an e-scooter up to 45 km/h. Implications: portable, not allowed on cycle lanes in general, except specific rules in certain countries<br/>
+            <br/>
+            `all` is to request one trip for each vehicle type described above (picking only one between `bicycle` and `folding-bicycle` according to `fb` parameter).
+          default: all
       responses:
         200:
           description: Successful response. Can include many trips.


### PR DESCRIPTION
API docs for new `me_mic` mode + `micVehicleType` parameter, and deprecated `cy_bic`. 