### PR TITLE
Rename shortName to platformCode

### DIFF
--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3540,7 +3540,7 @@ definitions:
       name:
         type: string
         description: Name of the stop (might include platform)
-      shortName:
+      platformCode:
         type: string
         description: Platform information of the stop. Might double-up with `name`.
       bearing:


### PR DESCRIPTION
`shortName` is still in the API but undocumented and will be removed later.