### PR TITLE
API spec proposal for geofence information

### DIFF
--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -5077,6 +5077,8 @@ components:
             required:
             - id
             - type
+            - center
+            - radius
             - trigger
             - messageType
             - messageTitle

--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -3391,7 +3391,7 @@ components:
           type: integer
           description: "If the corresponding vehicle_type definition for this vehicle\
             \ has a motor, then this field is required. This value represents the\
-            \ furthest distance in meters that the vehicle can travel without recharging\
+            \ furthest distance in metres that the vehicle can travel without recharging\
             \ or refueling with the vehicle's current charge or fuel."
     SharedVehicleTypeInfo:
       type: object
@@ -3403,7 +3403,7 @@ components:
           type: integer
           description: "If the vehicle has a motor (as indicated by having a value\
             \ other than human in the propulsion_type field), this field is required.\
-            \ This represents the furthest distance in meters that the vehicle can\
+            \ This represents the furthest distance in metres that the vehicle can\
             \ travel without recharging or refueling when it has the maximum amount\
             \ of energy potential (for example, a full battery or full tank of gas)."
         formFactor:
@@ -5036,6 +5036,51 @@ components:
           $ref: '#/components/schemas/ArrayOfSimpleDataSourceAttribution'
         localCost:
           $ref: '#/components/schemas/LocalCost'
+        geofences:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Unique identifier of geofence
+              type:
+                type: string
+                description: Type of geofence
+                enum:
+                - CIRCLE
+              trigger:
+                type: string
+                description: When to trigger geofence
+                enum:
+                - ENTER
+                - EXIT
+              center:
+                description: Center coordinate for circular geofences
+                $ref: '#/components/schemas/Cooordinate'
+              radius:
+                type: number
+                description: Radius of circular geofences in metres
+              messageType:
+                type: string
+                description: Type of message to show when geofence is triggered
+                enum:
+                - TRIP_END
+                - ARRIVING_AT_YOUR_STOP
+                - NEXT_STOP_IS_YOURS
+              messageTitle:
+                type: string
+                description: Localised title of message to show when entering geofence
+              messageBody:
+                type: string
+                description: Localised body of message to show when entering geofence
+            required:
+            - id
+            - type
+            - trigger
+            - messageType
+            - messageTitle
+            - messageBody
         mapTiles:
           required:
           - name


### PR DESCRIPTION
This adds a `geofences` array to trip segments, which can then be used by the frontend to set-up appropriate geofences for a trip. That way, we can make sure the logic is the same on iOS and Android, and we can also update and tweak it dynamically.