### PR TITLE
22751: add the `regions` definition in the info/*.json endpoints

### DIFF
--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -135,7 +135,7 @@ paths:
     post:
       tags:
       - Public Transport
-      summary: Operators for a region
+      summary: Operators for a region or group of regions
       description: Retrieves detailed information about covered transport service
         providers for a specified region.
       requestBody:
@@ -143,12 +143,18 @@ paths:
           application/json:
             schema:
               required:
-              - region
+              - regions
               type: object
               properties:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                regions:
+                  type: array
+                  description: Region names/codes from `regions.json`.
+                  items:
+                    type: string
+                    minimum: 1
                 modes:
                   type: array
                   description: "Public transit modes (`pt_pub_*`) for which results\
@@ -196,7 +202,7 @@ paths:
                 \ to a empty response. In order to prevent this, make sure such combinations\
                 \ are posible, using previously fetched information."
               example:
-                region: US_CA_LosAngeles
+                regions: [US_CA_LosAngeles, US_CA_Ventura]
                 modes:
                 - pt_pub_tram
                 - pt_pub_bus
@@ -288,12 +294,18 @@ paths:
           application/json:
             schema:
               required:
-              - region
+              - regions
               type: object
               properties:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                regions:
+                  type: array
+                  description: Region names/codes from `regions.json`.
+                  items:
+                    type: string
+                    minimum: 1
                 query:
                   type: string
                   description: Optional search string to filter routes by their short name (complete matches only) or by their name (partial matches)
@@ -346,7 +358,7 @@ paths:
                 \ response. In order to prevent this, make sure such combinations\
                 \ are posible, using previously fetched information."
               example:
-                region: US_CA_LosAngeles
+                region: [US_CA_LosAngeles]
                 operatorID: LACMTA_Rail
                 modes:
                 - pt_pub_tram
@@ -431,13 +443,19 @@ paths:
             schema:
               required:
               - operatorID
-              - region
+              - regions
               - routeID
               type: object
               properties:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                regions:
+                  type: array
+                  description: Region names/codes from `regions.json`.
+                  items:
+                    type: string
+                    minimum: 1
                 operatorID:
                   type: string
                   description: Operator ID from `info/routes.json` (or `info/operators.json`).
@@ -528,13 +546,19 @@ paths:
             schema:
               required:
               - operatorID
-              - region
+              - regions
               - routeID
               type: object
               properties:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                regions:
+                  type: array
+                  description: Region names/codes from `regions.json`.
+                  items:
+                    type: string
+                    minimum: 1
                 operatorID:
                   type: string
                   description: Operator ID from `info/routes.json` (or `info/operators.json`).
@@ -564,7 +588,7 @@ paths:
                 \ You can also retrieve information for a particular list of services\
                 \ using `serviceTripIDs`."
               example:
-                region: US_CA_LosAngeles
+                regions: [US_CA_LosAngeles]
                 operatorID: LACMTA_Rail
                 routeID: 806
                 serviceTripIDs:

--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -254,6 +254,11 @@ paths:
                     feedId:
                       type: string
                       description: unique source identifiers for this operator.
+                    regions:
+                      type: array
+                      description: Regions where this operator has services
+                      items:
+                        type: string
                     hasStableID:
                       type: boolean
                       description: When true, returned operator identifier is stable between data updates.

--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -149,6 +149,7 @@ paths:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                  deprecated: true
                 regions:
                   type: array
                   description: Region names/codes from `regions.json`.
@@ -300,6 +301,7 @@ paths:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                  deprecated: true
                 regions:
                   type: array
                   description: Region names/codes from `regions.json`.
@@ -450,6 +452,7 @@ paths:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                  deprecated: true
                 regions:
                   type: array
                   description: Region names/codes from `regions.json`.
@@ -553,6 +556,7 @@ paths:
                 region:
                   type: string
                   description: Region name/code from `regions.json`.
+                  deprecated: true
                 regions:
                   type: array
                   description: Region names/codes from `regions.json`.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -135,6 +135,7 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+                deprecated: true
               regions:
                 type: array
                 description: List of regions. The name/code should be from `regions.json`.
@@ -265,6 +266,7 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+                deprecated: true
               regions:
                 type: array
                 description: List of regions. The name/code should be from `regions.json`.
@@ -403,6 +405,7 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+                deprecated: true
               regions:
                 type: array
                 description: List of regions. The name/code should be from `regions.json`.

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -135,6 +135,11 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+              regions:
+                type: array
+                description: List of regions. The name/code should be from `regions.json`.
+                items:
+                  type: string
               modes:
                 type: array
                 items:
@@ -161,9 +166,9 @@ paths:
                 description: Boolean if result should include full information for operator/s or just a list with all their IDs ignoring `mode` array in response.
                 default: false
             required:
-              - region
+              - regions
             example:
-              region: US_CA_LosAngeles
+              regions: [US_WI_Milwaukee,US_WI_Madison]
               modes:
                 - pt_pub_tram
                 - pt_pub_bus
@@ -186,6 +191,11 @@ paths:
                 feedId:
                   type: string
                   description: unique source identifiers for this operator.
+                regions:
+                  type: array
+                  items:
+                    description: Regions where this operator has services
+                    type: string
                 hasStableID:
                   type: boolean
                   description: When true, returned operator identifier is stable between data updates.
@@ -207,6 +217,7 @@ paths:
             example:
               - id: LACMTA
                 name: Metro - Los Angeles
+                regions: [US_CA_LosAngeles]
                 modes:
                   - mode: pt_pub_tram
                     numberOfServices: 5698
@@ -218,11 +229,13 @@ paths:
                       - updates: true
               - id: 27
                 name: LADOT
+                regions: [US_CA_LosAngeles]
                 modes:
                   - mode: pt_pub_bus
                     numberOfServices: 15828
               - id: 6216179
                 name: Big Blue Bus
+                regions: [US_CA_LosAngeles]
                 modes:
                   - mode: pt_pub_bus
                     numberOfServices: 7702
@@ -252,6 +265,11 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+              regions:
+                type: array
+                description: List of regions. The name/code should be from `regions.json`.
+                items:
+                  type: string
               operatorID:
                 type: string
                 description: TSP ID from `info/operator.json`.
@@ -281,10 +299,10 @@ paths:
                 description: Boolean if result should include full information for route/s or just a list with all their IDs.
                 default: false
             required:
-              - region
+              - regions
               - operatorID
             example:
-              region: US_CA_LosAngeles
+              regions: [US_CA_LosAngeles]
               operatorID: LACMTA_Rail
               modes:
                 - pt_pub_tram
@@ -385,6 +403,11 @@ paths:
               region:
                 type: string
                 description: Region name/code from `regions.json`.
+              regions:
+                type: array
+                description: List of regions. The name/code should be from `regions.json`.
+                items:
+                  type: string
               operatorID:
                 type: string
                 description: TSP ID from `info/operator.json`.
@@ -406,11 +429,11 @@ paths:
                 description: Boolean if result should include full information for service/s or just a list with only `id` field in response.
                 default: false
             required:
-              - region
+              - regions
               - operatorID
               - routeID
             example:
-              region: US_CA_LosAngeles
+              region: [US_CA_LosAngeles]
               operatorID: LACMTA_Rail
               routeID:  806
               serviceTripIDs:


### PR DESCRIPTION
Redmine: [22751: Adjust info/*.json endpoints to a list of regions](https://redmine.buzzhives.com/issues/22751)
Satapp PR: https://github.com/skedgo/skedgo-java/pull/7211