### PR TITLE
Document wp factor clamping to [0.5, 2.0] (#25671)

### DIFF
--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -960,12 +960,7 @@ paths:
           default: "1"
       - name: wp
         in: query
-        description: "String with `(%f,%f,%f,%f)` format specifying the user's weighting\
-          \ profile. In order, the weights represent price, environmental impact,\
-          \ duration, and convenience. Each value should be between 0.1 and 2.0. 0.1\
-          \ means the related cost is unimportant and 2.0 means it's very important\
-          \ to the user. This impacts both the routing results and each trip's `weightedScore`\
-          \ value."
+        description: "String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.5 and 2.0. 0.5 means the related cost is least important and 2.0 means it's very important to the user. Values outside that range are accepted but clamped to these thresholds. This impacts both the routing results and each trip's `weightedScore` value."
         required: false
         style: form
         explode: true
@@ -2810,12 +2805,7 @@ components:
           default: false
         wp:
           type: string
-          description: "String with `(%f,%f,%f,%f)` format specifying the user's weighting\
-            \ profile. In order, the weights represent price, environmental impact,\
-            \ duration, and convenience. Each value should be between 0.1 and 2.0.\
-            \ 0.1 means the related cost is unimportant and 2.0 means it's very important\
-            \ to the user. This impacts both the routing results and each trip's `weightedScore`\
-            \ value."
+          description: "String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.5 and 2.0. 0.5 means the related cost is least important and 2.0 means it's very important to the user. Values outside that range are accepted but clamped to these thresholds. This impacts both the routing results and each trip's `weightedScore` value."
           default: "(1, 1, 1, 1)"
 
     WaypointInput:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -642,7 +642,7 @@ paths:
           type: string
           in: query
           description:
-            String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.1 and 2.0. 0.1 means the related cost is unimportant and 2.0 means it's very important to the user. This impacts both the routing results and each trip's `weightedScore` value.
+            String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.5 and 2.0. 0.5 means the related cost is least important and 2.0 means it's very important to the user. Values outside that range are accepted but clamped to these thresholds. This impacts both the routing results and each trip's `weightedScore` value.
           default: (1, 1, 1, 1)
         - name: conc
           description: If concession pricing should be use for public transport
@@ -1893,7 +1893,7 @@ definitions:
       wp:
         type: string
         description:
-          String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.1 and 2.0. 0.1 means the related cost is unimportant and 2.0 means it's very important to the user. This impacts both the routing results and each trip's `weightedScore` value.
+          String with `(%f,%f,%f,%f)` format specifying the user's weighting profile. In order, the weights represent price, environmental impact, duration, and convenience. Each value should be between 0.5 and 2.0. 0.5 means the related cost is least important and 2.0 means it's very important to the user. Values outside that range are accepted but clamped to these thresholds. This impacts both the routing results and each trip's `weightedScore` value.
         default: (1, 1, 1, 1)
     required:
       - v


### PR DESCRIPTION
Updates the public `wp` (weighting profile) parameter docs to reflect the server-side factor clamp.

**Change:** each factor is now documented as ranging **0.5–2.0** (was 0.1–2.0), with: *"Values outside that range are accepted but clamped to these thresholds."* Applied to both specs (4 spots total):
- `docs/specs/tripgo.openapi.yaml` (×2)
- `docs/specs/tripgo.swagger.yaml` (×2)

The two OpenAPI descriptions were normalised from folded multi-line to single-line scalars while editing — functionally identical, just a cleaner diff to read.

**Why:** reflects the `minWeightFactor` 0.1 → 0.5 clamp in skedgo/skedgo-java#8224 (Redmine #25671), which silently raises any sub-0.5 factor to 0.5. The old docs implied `0.1` is honored.

> ⚠️ **Draft — do not merge until the clamp is live in production.** Merging auto-deploys the docs (GHA), so this should only land once skedgo-java#8224 is deployed. Also note #8224 is one of two competing fixes (vs skedgo-java#8201, the decoupling approach); if the decoupling wins instead, the factor range stays 0.1–2.0 and this PR should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)