### PR TITLE
Deprecate region URL fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository contains the TripGo developer documentation and API reference site. Markdown pages live in `docs/`, with enterprise pages under `docs/enterprise/` and guides under `docs/guides/`. OpenAPI and Swagger reference files are in `docs/specs/`; generated reference outputs are also committed under `generated/`. Static assets are in `docs/img/`, `docs/swagger/`, and `docs/redoc/`. MkDocs configuration is in `mkdocs.yml`, custom theme overrides are in `overrides/`, and Sass/CSS sources are in `sass/`.
+
+## Build, Test, and Development Commands
+
+- `pip install -r requirements.txt`: installs repository-pinned Python documentation dependencies.
+- `pip install mkdocs pymdown-extensions`: installs the MkDocs tooling referenced by `INSTRUCTIONS.md`.
+- `pip install git+https://github.com/duduct/skedgo-mkdocs-theme`: installs the custom SkedGo MkDocs theme required by `mkdocs.yml`.
+- `mkdocs serve`: runs the documentation site locally for editing.
+- `mkdocs build --strict`: builds the static site and fails on strict navigation, link, or configuration issues.
+
+## Coding Style & Naming Conventions
+
+Use concise Markdown with descriptive headings and stable anchor text. Keep YAML files indented with two spaces and avoid reformatting large generated OpenAPI files unless the change requires it. Name new docs with lowercase, hyphenated filenames such as `deep-links.md`. Keep assets grouped by purpose: images in `docs/img/`, API specs in `docs/specs/`, and theme overrides in `overrides/`.
+
+## Testing Guidelines
+
+There is no application test suite in this repository. Treat `mkdocs build --strict` as the primary validation step before submitting changes. For OpenAPI edits, also inspect the affected generated ReDoc or Swagger page locally through `mkdocs serve` and verify examples remain valid YAML or JSON.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use short, imperative summaries, often with an issue or PR reference, for example `Update navigation (#264)` or `RM24024: fix agenda/run body example. (#270)`. Keep commits focused on one documentation or spec change. Pull requests should describe the user-visible documentation impact, link related issues or tickets, and include screenshots only when layout, styling, or rendered reference pages change.
+
+## Security & Configuration Tips
+
+Do not commit API keys, credentials, or private customer examples. Follow `SECURITY.md` for vulnerability reporting. When editing specs, prefer synthetic request and response examples unless real data has been explicitly approved for public documentation.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,13 +24,7 @@ You can get a list of regions by quering [`regions.json`](/#tag/Configuration%2F
 curl 'https://api.tripgo.com/v1/regions.json' -H 'Content-Type: application/json' --compressed -H "X-TripGo-Key: $tripgoKey" -d '{"v":2}'
 ```
 
-Then extract the polylines from there and match your coordinates to a region. This endpoint also tells you which modes are supported by routing for a given region. 
-
-> I noticed URLs in those regions, how can/should I use those?
-
-Most developer should not need to worry about these and can just use the `api.tripgo.com` domain. However, performance critical application can use this to reduce lag and directly hit the routing servers.
-
-*For advanced users*: This exposes to you that our API is covered by multiple servers - though not every server covers ever region. You can use the URLs to directly query servers covering a certain region – which can be beneficial to reduce lag and is recommended for server-to-server communication. However, be aware that you should add failover from one server to another yourself then, as individual servers can go down unannounced for maintenance. You should only cache this information short term as those URLs can change without notice.
+Then extract the polylines from there and match your coordinates to a region. This endpoint also tells you which modes are supported by routing for a given region.
 
 ---
 

--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -4275,7 +4275,6 @@ components:
       - modes
       - name
       - polygon
-      - urls
       type: object
       properties:
         name:
@@ -4322,8 +4321,9 @@ components:
           items:
             type: string
         urls:
+          deprecated: true
           type: array
-          description: Array of base URLs of SkedGo servers which cover this region.
+          description: Deprecated, optional legacy base URLs of SkedGo servers which cover this region. Use the main TripGo API host instead.
           items:
             type: string
       example:
@@ -4345,8 +4345,6 @@ components:
         - cy_bic
         - cy_bic-s_NORIS
         - wa_wal
-        urls:
-        - nuremberg-bv-de.hadron.buzzhives.com
     RealTimeData:
       type: object
       properties:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -54,11 +54,10 @@ paths:
     post:
       tags:
         - Configuration
-      summary: Available regions with host names per region
+      summary: Available regions
       description:
-        Lists available regions, their server host names and available
-        transport modes. Provide optional hash code to only return output
-        if the data has changed.
+        Lists available regions and available transport modes. Provide
+        optional hash code to only return output if the data has changed.
       parameters:
         - name: input
           in: body
@@ -3154,7 +3153,8 @@ definitions:
           type: string
       urls:
         type: array
-        description: Array of base URLs of SkedGo servers which cover this region.
+        deprecated: true
+        description: Deprecated, optional legacy base URLs of SkedGo servers which cover this region. Use the main TripGo API host instead.
         items:
           type: string
     required:
@@ -3162,7 +3162,6 @@ definitions:
       - polygon
       - cities
       - modes
-      - urls
     example:
       name: DE_BV_Nuremberg
       polygon: SDf9723rhkjFKHAFB
@@ -3182,8 +3181,6 @@ definitions:
         - cy_bic
         - cy_bic-s_NORIS
         - wa_wal
-      urls:
-        - nuremberg-bv-de.hadron.buzzhives.com
 
   RealTimeData:
     description: Real Time availability.


### PR DESCRIPTION
Summary: remove FAQ guidance for region URLs; mark Region.urls deprecated and optional in Swagger/OpenAPI specs; add repository contributor guide.

Validation: git diff --check passed; OpenAPI YAML parsed; mkdocs build --strict passed with output directed to /tmp/tripgo-api-site-build.