### PR TITLE
25898: document realtimeVehicleAlternatives is trip-update-only

### DIFF
--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -5040,7 +5040,7 @@ components:
         realtimeVehicleAlternatives:
           type: array
           description: |
-            Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
+            Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET /trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
           items:
             $ref: '#/components/schemas/RealTimeVehicle'
         realTimeStatus:

--- a/docs/specs/tripgo.openapi.yaml
+++ b/docs/specs/tripgo.openapi.yaml
@@ -5039,6 +5039,8 @@ components:
           $ref: '#/components/schemas/RealTimeVehicle'
         realtimeVehicleAlternatives:
           type: array
+          description: |
+            Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
           items:
             $ref: '#/components/schemas/RealTimeVehicle'
         realTimeStatus:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3842,7 +3842,7 @@ definitions:
       realtimeVehicleAlternatives:
         type: array
         description: |
-          Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
+          Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET /trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
         items:
           $ref: '#/definitions/RealTimeVehicle'
       realTimeStatus:

--- a/docs/specs/tripgo.swagger.yaml
+++ b/docs/specs/tripgo.swagger.yaml
@@ -3841,6 +3841,8 @@ definitions:
         $ref: '#/definitions/RealTimeVehicle'
       realtimeVehicleAlternatives:
         type: array
+        description: |
+          Other real-time vehicles operating the same route around this time, each with full per-vehicle detail (e.g. individual carriage make and occupancy). Only returned by the trip update endpoint (`GET trip/update/{id}`); it is omitted from routing/list responses such as `routing.json`, where this detail can grow very large across a response with many trips.
         items:
           $ref: '#/definitions/RealTimeVehicle'
       realTimeStatus:


### PR DESCRIPTION
## What

Documents the `realtimeVehicleAlternatives` property on a segment reference, which previously had **no description** in either spec file (`tripgo.openapi.yaml` / `tripgo.swagger.yaml`).

It now states that the field:
- embeds full per-vehicle detail (e.g. individual carriage make and occupancy), and
- is **only returned by the trip update endpoint** (`trip/update/{id}`) — it is omitted from routing/list responses such as `routing.json`.

## Why

In routing responses this field is unbounded and combinatorial: a single Sydney query reproduced 70 segments each carrying up to 31 alternative vehicles (1,717 carriage-detail entries), ballooning the response to multiple MB.

Note: this is the segment field `realtimeVehicleAlternatives`, distinct from the separately-named `realtimeAlternativeVehicle` on the departures/service (`ServiceDeparture`, `/latest.json`) responses, which is unchanged.
